### PR TITLE
Calculates meters_to_prev in the research_positions, loitering requires it

### DIFF
--- a/assets/queries/research_positions_query.sql.j2
+++ b/assets/queries/research_positions_query.sql.j2
@@ -57,6 +57,7 @@ WITH
 
 # Return
 SELECT
+  msgid,
   lat,
   lon,
   speed,

--- a/assets/queries/research_positions_query.sql.j2
+++ b/assets/queries/research_positions_query.sql.j2
@@ -1,6 +1,18 @@
 #standardSQL
 
 #
+# Return the distance between two lat/lon locations in meters
+# if any of the parameters are null, returns null
+# if the distance is less than .0001 degrees, returns 0
+#
+CREATE TEMP FUNCTION distance_m(lat1 FLOAT64, lon1 FLOAT64, lat2 FLOAT64, lon2 FLOAT64) AS (
+    IF (
+      (ABS(lat2 - lat1) < .0001 AND ABS(lon2- lon1) < .0001 ),
+      0.0,
+      ACOS( COS(0.01745329251 * (90 - lat1)) * COS(0.01745329251 * (90 - lat2)) + SIN(0.01745329251 * (90 - lat1)) * SIN(0.01745329251 * (90 - lat2)) * COS(0.01745329251 * (lon2 - lon1)) ) * 6371000
+    ));
+
+#
 # Return the absolute value of the diff between the two timestamps in hours with microsecond precision
 # If either parameter is null, return null
 #
@@ -10,39 +22,38 @@ CREATE TEMP FUNCTION
 
 WITH
   positions AS (
-  SELECT
-    ssvid,
-    msgid,
-    seg_id,
-    lat,
-    lon,
-    speed,
-    course,
-    timestamp,
-    LAG(timestamp, 1) OVER (PARTITION BY seg_id ORDER BY timestamp) prev_timestamp,
-    nnet_score,
-    distance_from_port_m,
-    distance_from_shore_m,
-    elevation_m,
-    lower(source) as source
-  FROM
-    `{{ source }}`
-  WHERE _table_suffix >= '{{ date_from }}' and _table_suffix < '{{ date_to }}'),
-  pos_hours AS (
-  SELECT
-    *,
-  IF
-    (nnet_score > 0.5,
-      hours,
-      0) AS fishing_hours
-  FROM (
+    SELECT
+      ssvid,
+      msgid,
+      seg_id,
+      lat,
+      lon,
+      speed,
+      course,
+      timestamp,
+      LAG(timestamp, 1) OVER (PARTITION BY seg_id ORDER BY timestamp) prev_timestamp,
+      LAG(lat, 1) OVER (PARTITION BY seg_id ORDER BY timestamp) prev_lat,
+      LAG(lon, 1) OVER (PARTITION BY seg_id ORDER BY timestamp) prev_lon,
+      nnet_score,
+      distance_from_port_m,
+      distance_from_shore_m,
+      elevation_m,
+      lower(source) as source
+    FROM
+      `{{ source }}`
+    WHERE _table_suffix >= '{{ date_from }}' and _table_suffix < '{{ date_to }}'),
+  pos_relative_prev_seg as (
     SELECT
       *,
-      IFNULL (hours_diff_abs (timestamp,
-          prev_timestamp),
-        0) hours
+      IFNULL (hours_diff_abs (timestamp, prev_timestamp), 0) hours,
+      IFNULL (distance_m (prev_lat, prev_lon, lat, lon), 0) meters_to_prev,
     FROM
-      positions ) )
+      positions),
+  pos_fishing_hours AS (
+    SELECT
+      *,
+      IF (nnet_score > 0.5, hours, 0) AS fishing_hours
+    FROM pos_relative_prev_seg )
 
 # Return
 SELECT
@@ -58,6 +69,7 @@ SELECT
   distance_from_port_m,
   distance_from_shore_m,
   elevation_m,
-  source
+  source,
+  meters_to_prev
 FROM
-  pos_hours
+  pos_fishing_hours

--- a/pipe_vms_research/research_positions.py
+++ b/pipe_vms_research/research_positions.py
@@ -25,6 +25,7 @@ def create_table_if_not_exists(client, destination_table_ref):
         table = client.get_table(destination_table_ref) #API request
     except NotFound:
         schema = [
+            bigquery.SchemaField('msgid', 'STRING', description='A unique message id to be use to join to posterior pipeline output tables.'),
             bigquery.SchemaField('lat', 'FLOAT', description='The latitude where the vessel was positioned.'),
             bigquery.SchemaField('lon', 'FLOAT', description='The longitude where the vessel was positioned.'),
             bigquery.SchemaField('speed', 'FLOAT', description='The speed of the vessel.'),

--- a/pipe_vms_research/research_positions.py
+++ b/pipe_vms_research/research_positions.py
@@ -37,7 +37,8 @@ def create_table_if_not_exists(client, destination_table_ref):
             bigquery.SchemaField('distance_from_port_m', 'FLOAT', description='The distance from port.'),
             bigquery.SchemaField('distance_from_shore_m', 'FLOAT', description='The distance from shore.'),
             bigquery.SchemaField('elevation_m', 'FLOAT', description='The elevation.'),
-            bigquery.SchemaField('source', 'STRING', description='The source which the message belongs.')
+            bigquery.SchemaField('source', 'STRING', description='The source which the message belongs.'),
+            bigquery.SchemaField('meters_to_prev', 'FLOAT', description='Distance (meters) to the previous point in the segment.')
         ]
         table = bigquery.Table(destination_table_ref, schema=schema)
         table.time_partitioning = bigquery.TimePartitioning(


### PR DESCRIPTION
Affects VMS pipe-v3.
- For calculate loitering we need to know the `meters_to_prev` of the previous segment. The research SQL gets the meters_to_prev using the `prev_lat` and `prev_lon` and the function `distance_m`.
- Increments the project version.

Related with> https://globalfishingwatch.atlassian.net/browse/VMS-123